### PR TITLE
fix mdx depends

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,7 +14,7 @@
   (tags (emoji unicode))
   (depends
     (ocaml (>= "4.04"))
-    (mdx :with-dev-setup)
+    (mdx :with-test)
     (lambdasoup :with-dev-setup)
     (uutf :with-dev-setup)
   ))

--- a/emoji.opam
+++ b/emoji.opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/fxfactorial/ocaml-emoji/issues"
 depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "4.04"}
-  "mdx" {with-dev-setup}
+  "mdx" {with-test}
   "lambdasoup" {with-dev-setup}
   "uutf" {with-dev-setup}
   "odoc" {with-doc}


### PR DESCRIPTION
Fix for `"mdx.top" not found` on `dune runtest`